### PR TITLE
Update solana devnet minters

### DIFF
--- a/usdc/solana/minters.json
+++ b/usdc/solana/minters.json
@@ -1,4 +1,4 @@
 {
-  "testnet": ["2Dp4uY4BTeZonXatVn95cE3Ps7kPWqvkTxQjGDo4Vcpq", "54kEMXXt7wbbyuiZ5Ns5HjGywunZogW44GKPznsdsVkg"],
+  "devnet": ["9JywdjbDkb8a3nqcouuLV8TDZ2UA8whwpMN5Eett6b2h", "AKy7FobAN2PqQhZpq3egmgNs4qB6RH4fkUy9o1gw8qJa"],
   "mainnet": ["27T5c11dNMXjcRuko9CeUy3Wq41nFdH3tz9Qt4REzZMM", "28VqfqsUUBx59i8ruG2TuC5RekW5ZY3tsK4bSV59sXjn", "3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa"]
 }


### PR DESCRIPTION
Updating the minter addresses since the switch from testnet to devnet:
https://explorer.solana.com/address/9JywdjbDkb8a3nqcouuLV8TDZ2UA8whwpMN5Eett6b2h?cluster=devnet
https://explorer.solana.com/address/AKy7FobAN2PqQhZpq3egmgNs4qB6RH4fkUy9o1gw8qJa?cluster=devnet
