### PR TITLE
Adding minters info for statemint blockchain

### DIFF
--- a/usdc/statemint/minters.json
+++ b/usdc/statemint/minters.json
@@ -1,0 +1,4 @@
+{
+  "westmint": ["5Ci2oht7ATxgv2wUj5DW4F6Lh75v8pXnHP6sUSMBzPXKjNGj", "5EMMKa93Qfu7Zk3wBryt8MiVH646auLMakb19wBMiSSAWE8U"],
+  "statemint": ["14khzbBopeid31EETq8sTz8r9LYcBMTHqrKMnwgQyHkHSwBp", "15QjVp1rx6tjbBjmaWhhwUV7ESHMG6KjdDdhRuw5dQKWkqzB"]
+}


### PR DESCRIPTION
This PR adds minter addresses for statemint blockchain. Here are the addresses that are added:
Westmint:
* 5Ci2oht7ATxgv2wUj5DW4F6Lh75v8pXnHP6sUSMBzPXKjNGj
* 5EMMKa93Qfu7Zk3wBryt8MiVH646auLMakb19wBMiSSAWE8U
Statemint:
* 14khzbBopeid31EETq8sTz8r9LYcBMTHqrKMnwgQyHkHSwBp
* 15QjVp1rx6tjbBjmaWhhwUV7ESHMG6KjdDdhRuw5dQKWkqzB